### PR TITLE
JP - Enables sbt-header plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,12 @@ lazy val root = (project in file("."))
   .aggregate(`evaluator-server`, `evaluator-shared`, `evaluator-client`)
 
 lazy val `evaluator-shared` = (project in file("shared"))
+  .enablePlugins(AutomateHeaderPlugin)
   .settings(name := "evaluator-shared")
 
 lazy val `evaluator-client` = (project in file("client"))
   .dependsOn(`evaluator-shared`)
+  .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "evaluator-client",
     libraryDependencies <++= libraryVersions { v => Seq(
@@ -25,6 +27,7 @@ lazy val `evaluator-client` = (project in file("client"))
 lazy val `evaluator-server` = (project in file("server"))
   .dependsOn(`evaluator-shared`)
   .enablePlugins(JavaAppPackaging)
+  .enablePlugins(AutomateHeaderPlugin)
   .settings(
     name := "evaluator-server",
     libraryDependencies <++= libraryVersions { v => Seq(

--- a/client/src/main/scala/org/scalaexercises/evaluator/Decoders.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/Decoders.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import io.circe._, io.circe.jawn._, io.circe.syntax._

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import cats.data.Xor

--- a/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator.api
 
 import org.scalaexercises.evaluator.EvaluatorResponses.EvaluationResponse

--- a/client/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator.http
 
 import io.circe.Decoder

--- a/client/src/main/scala/org/scalaexercises/evaluator/http/HttpRequestBuilder.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/http/HttpRequestBuilder.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator.http
 
 import org.scalaexercises.evaluator.http.HttpClient._

--- a/project/EvaluatorBuild.scala
+++ b/project/EvaluatorBuild.scala
@@ -1,11 +1,13 @@
 import org.scalafmt.sbt.ScalaFmtPlugin
 import org.scalafmt.sbt.ScalaFmtPlugin.autoImport._
+import de.heikoseeberger.sbtheader.{HeaderPattern, HeaderPlugin}
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys._
 import sbt._
 
 object EvaluatorBuild extends AutoPlugin {
 
-  override def requires = plugins.JvmPlugin && ScalaFmtPlugin
+  override def requires = plugins.JvmPlugin && ScalaFmtPlugin && HeaderPlugin
 
   override def trigger = allRequirements
 
@@ -69,6 +71,16 @@ object EvaluatorBuild extends AutoPlugin {
   )
 
   private[this] def miscSettings = Seq(
+    headers <<= (name, version) { (name, version) => Map(
+      "scala" -> (
+        HeaderPattern.cStyleBlockComment,
+        s"""|/*
+            | * scala-exercises-$name
+            | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+            | */
+            |
+          |""".stripMargin)
+    )},
     shellPrompt := { s: State =>
       val c = scala.Console
       val blue = c.RESET + c.BLUE + c.BOLD

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.11")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")

--- a/server/src/main/scala/auth.scala
+++ b/server/src/main/scala/auth.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-server
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import org.http4s._, org.http4s.dsl._, org.http4s.server._

--- a/server/src/main/scala/codecs.scala
+++ b/server/src/main/scala/codecs.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-server
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import org.http4s._, org.http4s.dsl._

--- a/server/src/main/scala/evaluation.scala
+++ b/server/src/main/scala/evaluation.scala
@@ -1,5 +1,5 @@
 /*
- * scala-exercises-evaluator
+ * scala-exercises-evaluator-server
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 

--- a/server/src/main/scala/services.scala
+++ b/server/src/main/scala/services.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-server
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import org.http4s._, org.http4s.dsl._, org.http4s.server._

--- a/server/src/test/scala/EvalEndpointSpec.scala
+++ b/server/src/test/scala/EvalEndpointSpec.scala
@@ -1,7 +1,8 @@
 /*
- * scala-exercises-evaluator
+ * scala-exercises-evaluator-server
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
+
 package org.scalaexercises.evaluator
 
 import org.scalatest._

--- a/server/src/test/scala/EvaluatorSpec.scala
+++ b/server/src/test/scala/EvaluatorSpec.scala
@@ -1,11 +1,12 @@
 /*
- * scala-exercises-evaluator
+ * scala-exercises-evaluator-server
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
 package org.scalaexercises.evaluator
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import monix.execution.Scheduler
 import org.scalatest._
 

--- a/shared/src/main/scala/org/scalaexercises/evaluator/types.scala
+++ b/shared/src/main/scala/org/scalaexercises/evaluator/types.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises-evaluator-shared
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package org.scalaexercises.evaluator
 
 import scala.concurrent.duration._


### PR DESCRIPTION
This PR adds the [sbt-header](https://github.com/sbt/sbt-header) plugin to the evaluator project and enables it for all the sbt submodules.

Please, @dialelo @raulraja could you take a look at it? Thanks!