### PR TITLE
JP - Adds publish settings to the SBT configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,3 +52,4 @@ lazy val `evaluator-server` = (project in file("server"))
   .settings(compilerDependencySettings: _*)
 
 onLoad in Global := (Command.process("project evaluator-server", _: State)) compose (onLoad in Global).value
+addCommandAlias("publishSignedAll", ";evaluator-shared/publishSigned;evaluator-client/publishSigned")

--- a/project/EvaluatorBuild.scala
+++ b/project/EvaluatorBuild.scala
@@ -2,6 +2,7 @@ import org.scalafmt.sbt.ScalaFmtPlugin
 import org.scalafmt.sbt.ScalaFmtPlugin.autoImport._
 import de.heikoseeberger.sbtheader.{HeaderPattern, HeaderPlugin}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import com.typesafe.sbt.SbtPgp.autoImport._
 import sbt.Keys._
 import sbt._
 
@@ -31,6 +32,7 @@ object EvaluatorBuild extends AutoPlugin {
     baseSettings ++
       reformatOnCompileSettings ++
       dependencySettings ++
+      publishSettings ++
       miscSettings
 
 
@@ -89,6 +91,41 @@ object EvaluatorBuild extends AutoPlugin {
       val projectName = Project.extract(s).currentProject.id
 
       s"$blue$projectName$white>${c.RESET}"
+    }
+  )
+
+  private[this] lazy val gpgFolder = sys.env.getOrElse("SE_GPG_FOLDER", ".")
+
+  private[this] lazy val publishSettings = Seq(
+    organizationName := "Scala Exercises",
+    organizationHomepage := Some(new URL("http://scala-exercises.org")),
+    startYear := Some(2016),
+    description := "Scala Exercises: The path to enlightenment",
+    homepage := Some(url("http://scala-exercises.org")),
+    pgpPassphrase := Some(sys.env.getOrElse("SE_GPG_PASSPHRASE", "").toCharArray),
+    pgpPublicRing := file(s"$gpgFolder/pubring.gpg"),
+    pgpSecretRing := file(s"$gpgFolder/secring.gpg"),
+    credentials += Credentials(
+      "Sonatype Nexus Repository Manager",
+      "oss.sonatype.org",
+      sys.env.getOrElse("PUBLISH_USERNAME", ""),
+      sys.env.getOrElse("PUBLISH_PASSWORD", "")),
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/scala-exercises/evaluator"),
+        "https://github.com/scala-exercises/evaluator.git"
+      )
+    ),
+    licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    pomIncludeRepository := Function.const(false),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("Snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("Releases" at nexus + "service/local/staging/deploy/maven2")
     }
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.11")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")


### PR DESCRIPTION
This PR provides the publish settings in order to be able to publish the artifacts that are working as lib, these are: `evaluator-shared` and `evaluator-client`.

Also, it brings an sbt task, `publishSignedAll`, to achive the publish in a single step.

Snapshot published at this moment:

* [Shared](https://oss.sonatype.org/content/repositories/snapshots/org/scala-exercises/evaluator-shared_2.11/0.0.1-SNAPSHOT/)
* [Client](https://oss.sonatype.org/content/repositories/snapshots/org/scala-exercises/evaluator-client_2.11/0.0.1-SNAPSHOT/)

Please, @dialelo @raulraja Have a look when you have a chance. Thanks!