### PR TITLE
JP - Adds free algebra for Evaluator Client API

### DIFF
--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
@@ -1,0 +1,17 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator
+
+import org.scalaexercises.evaluator.free.algebra.{EvaluatorOp, EvaluatorOps}
+
+class EvaluatorAPI(url: String, authKey: String)(
+  implicit O: EvaluatorOps[EvaluatorOp]) {
+
+  def evaluates(resolvers: List[String] = Nil,
+                dependencies: List[Dependency] = Nil,
+                code: String) =
+    O.evaluates(url, authKey, resolvers, dependencies, code)
+}

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
@@ -1,0 +1,34 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator
+
+import cats.data.XorT
+import cats.{MonadError, ~>}
+import org.scalaexercises.evaluator.EvaluatorResponses.{EvaluationException, EvaluationResponse, EvaluationResult, EvalIO}
+import org.scalaexercises.evaluator.free.algebra.EvaluatorOp
+
+class EvaluatorClient(url: String, authKey: String) {
+
+  lazy val api = new EvaluatorAPI(url, authKey)
+
+}
+
+object EvaluatorClient {
+
+  def apply(url: String, authKey: String) = new EvaluatorClient(url, authKey)
+
+  implicit class EvaluationIOSyntaxXOR[A](
+    evalIO: EvalIO[EvaluationResponse[A]]) {
+
+    def exec[M[_]](implicit I: (EvaluatorOp ~> M),
+                   A: MonadError[M, Throwable]): M[EvaluationResponse[A]] =
+      evalIO foldMap I
+
+    def liftEvaluator: XorT[EvalIO, EvaluationException, EvaluationResult[A]] =
+      XorT[EvalIO, EvaluationException, EvaluationResult[A]](evalIO)
+
+  }
+}

--- a/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
@@ -6,7 +6,7 @@
 package org.scalaexercises.evaluator.api
 
 import org.scalaexercises.evaluator.EvaluatorResponses.EvaluationResponse
-import org.scalaexercises.evaluator.{Decoders, EvalRequest, EvalResponse}
+import org.scalaexercises.evaluator.{Decoders, Dependency, EvalRequest, EvalResponse}
 import org.scalaexercises.evaluator.http.HttpClient
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -19,8 +19,12 @@ class Evaluator {
 
   def eval(url: String,
            authKey: String,
-           evalRequest: EvalRequest): EvaluationResponse[EvalResponse] =
-    httpClient
-      .post[EvalResponse](url, authKey, data = evalRequest.asJson.noSpaces)
+           resolvers: List[String] = Nil,
+           dependencies: List[Dependency] = Nil,
+           code: String): EvaluationResponse[EvalResponse] =
+    httpClient.post[EvalResponse](
+      url,
+      authKey,
+      data = EvalRequest(resolvers, dependencies, code).asJson.noSpaces)
 
 }

--- a/client/src/main/scala/org/scalaexercises/evaluator/free/algebra/EvaluatorOps.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/free/algebra/EvaluatorOps.scala
@@ -1,0 +1,39 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator.free.algebra
+
+import cats.free.{Free, Inject}
+import org.scalaexercises.evaluator.{Dependency, EvalResponse}
+import org.scalaexercises.evaluator.EvaluatorResponses.EvaluationResponse
+
+sealed trait EvaluatorOp[A]
+final case class Evaluates(url: String,
+                           authKey: String,
+                           resolvers: List[String] = Nil,
+                           dependencies: List[Dependency] = Nil,
+                           code: String)
+    extends EvaluatorOp[EvaluationResponse[EvalResponse]]
+
+class EvaluatorOps[F[_]](implicit I: Inject[EvaluatorOp, F]) {
+
+  def evaluates(
+    url: String,
+    authKey: String,
+    resolvers: List[String] = Nil,
+    dependencies: List[Dependency] = Nil,
+    code: String
+  ): Free[F, EvaluationResponse[EvalResponse]] =
+    Free.inject[EvaluatorOp, F](
+      Evaluates(url, authKey, resolvers, dependencies, code))
+
+}
+
+object EvaluatorOps {
+
+  implicit def instance[F[_]](
+    implicit I: Inject[EvaluatorOp, F]): EvaluatorOps[F] = new EvaluatorOps[F]
+
+}

--- a/client/src/main/scala/org/scalaexercises/evaluator/free/interpreters/Interpreter.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/free/interpreters/Interpreter.scala
@@ -1,0 +1,37 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator.free.interpreters
+
+import cats.{ApplicativeError, Eval, MonadError, ~>}
+import org.scalaexercises.evaluator.api.Evaluator
+import org.scalaexercises.evaluator.free.algebra.{Evaluates, EvaluatorOp}
+
+import scala.language.higherKinds
+
+trait Interpreter {
+
+  implicit def interpreter[M[_]](
+    implicit A: MonadError[M, Throwable]
+  ): EvaluatorOp ~> M = evaluatorOpsInterpreter[M]
+
+  /**
+    * Lifts Evaluator Ops to an effect capturing Monad such as Task via natural transformations
+    */
+  def evaluatorOpsInterpreter[M[_]](
+    implicit A: ApplicativeError[M, Throwable]): EvaluatorOp ~> M =
+    new (EvaluatorOp ~> M) {
+
+      val evaluator = new Evaluator()
+
+      def apply[A](fa: EvaluatorOp[A]): M[A] = fa match {
+        case Evaluates(url, authKey, resolvers, dependencies, code) ⇒
+          A.pureEval(
+            Eval.later(
+              evaluator.eval(url, authKey, resolvers, dependencies, code)))
+      }
+
+    }
+}

--- a/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
@@ -7,13 +7,12 @@ package org.scalaexercises.evaluator
 
 import cats.std.FutureInstances
 import cats.std.future._
-import cats.{Eval, Id, Monad, MonadError}
+import cats.{Eval, MonadError}
 import org.scalaexercises.evaluator.free.interpreters.Interpreter
 
 object implicits
     extends Interpreter
     with EvalInstances
-    with IdInstances
     with FutureInstances
 
 trait EvalInstances {
@@ -40,33 +39,6 @@ trait EvalInstances {
             case e: Throwable ⇒ f(e).value
           }
         })
-    }
-
-}
-
-trait IdInstances {
-
-  implicit def idMonadError(implicit I: Monad[Id]): MonadError[Id, Throwable] =
-    new MonadError[Id, Throwable] {
-
-      override def pure[A](x: A): Id[A] = I.pure(x)
-
-      override def ap[A, B](ff: Id[A ⇒ B])(fa: Id[A]): Id[B] = I.ap(ff)(fa)
-
-      override def map[A, B](fa: Id[A])(f: Id[A ⇒ B]): Id[B] = I.map(fa)(f)
-
-      override def flatMap[A, B](fa: Id[A])(f: A ⇒ Id[B]): Id[B] =
-        I.flatMap(fa)(f)
-
-      override def raiseError[A](e: Throwable): Id[A] = throw e
-
-      override def handleErrorWith[A](fa: Id[A])(f: Throwable ⇒ Id[A]): Id[A] = {
-        try {
-          fa
-        } catch {
-          case e: Exception ⇒ f(e)
-        }
-      }
     }
 
 }

--- a/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
@@ -1,0 +1,72 @@
+/*
+ * scala-exercises-evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator
+
+import cats.std.FutureInstances
+import cats.std.future._
+import cats.{Eval, Id, Monad, MonadError}
+import org.scalaexercises.evaluator.free.interpreters.Interpreter
+
+object implicits
+    extends Interpreter
+    with EvalInstances
+    with IdInstances
+    with FutureInstances
+
+trait EvalInstances {
+
+  implicit val evalMonadError: MonadError[Eval, Throwable] =
+    new MonadError[Eval, Throwable] {
+
+      override def pure[A](x: A): Eval[A] = Eval.now(x)
+
+      override def map[A, B](fa: Eval[A])(f: A ⇒ B): Eval[B] = fa.map(f)
+
+      override def flatMap[A, B](fa: Eval[A])(ff: A ⇒ Eval[B]): Eval[B] =
+        fa.flatMap(ff)
+
+      override def raiseError[A](e: Throwable): Eval[A] =
+        Eval.later({ throw e })
+
+      override def handleErrorWith[A](fa: Eval[A])(
+        f: Throwable ⇒ Eval[A]): Eval[A] =
+        Eval.later({
+          try {
+            fa.value
+          } catch {
+            case e: Throwable ⇒ f(e).value
+          }
+        })
+    }
+
+}
+
+trait IdInstances {
+
+  implicit def idMonadError(implicit I: Monad[Id]): MonadError[Id, Throwable] =
+    new MonadError[Id, Throwable] {
+
+      override def pure[A](x: A): Id[A] = I.pure(x)
+
+      override def ap[A, B](ff: Id[A ⇒ B])(fa: Id[A]): Id[B] = I.ap(ff)(fa)
+
+      override def map[A, B](fa: Id[A])(f: Id[A ⇒ B]): Id[B] = I.map(fa)(f)
+
+      override def flatMap[A, B](fa: Id[A])(f: A ⇒ Id[B]): Id[B] =
+        I.flatMap(fa)(f)
+
+      override def raiseError[A](e: Throwable): Id[A] = throw e
+
+      override def handleErrorWith[A](fa: Id[A])(f: Throwable ⇒ Id[A]): Id[A] = {
+        try {
+          fa
+        } catch {
+          case e: Exception ⇒ f(e)
+        }
+      }
+    }
+
+}


### PR DESCRIPTION
This PR brings a preliminary version of the free algebra to interact with the evaluator service.

In this way, this would be an example of use case:

```scala
val client = new EvaluatorClient("<evaluator-service-url>",  "<evaluator-auth-key>")

  val response: Free[EvaluatorOp, EvaluationResponse[EvalResponse]] =
    client.api.evaluates(
      dependencies = List(
        Dependency(
          groupId = "org.typelevel",
          artifactId = "cats_2.11",
          version = "0.6.1")),
      code = "{import cats._; Eval.now(42).value}")

  response.exec[Eval].value match {
    case Xor.Right(EvaluationResult(result, _, _)) ⇒
      println(result)
    case Xor.Left(ex) ⇒ throw ex
  }
```

Please, @dialelo @raulraja Could you review it? Thanks!