### PR TITLE
Parameterize API with respect to Free type `F`

### DIFF
--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
@@ -11,16 +11,14 @@ import org.scalaexercises.evaluator.free.algebra.{EvaluatorOp, EvaluatorOps}
 
 import scala.concurrent.duration.Duration
 
-class EvaluatorAPI(
-  url: String,
-  authKey: String,
-  connTimeout: Duration,
-  readTimeout: Duration)(implicit O: EvaluatorOps[EvaluatorOp]) {
+class EvaluatorAPI[F[_]](url: String,
+                         authKey: String,
+                         connTimeout: Duration,
+                         readTimeout: Duration)(implicit O: EvaluatorOps[F]) {
 
-  def evaluates(
-    resolvers: List[String] = Nil,
-    dependencies: List[Dependency] = Nil,
-    code: String): Free[EvaluatorOp, EvaluationResponse[EvalResponse]] =
+  def evaluates(resolvers: List[String] = Nil,
+                dependencies: List[Dependency] = Nil,
+                code: String): Free[F, EvaluationResponse[EvalResponse]] =
     O.evaluates(
       url,
       authKey,

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
@@ -18,7 +18,8 @@ class EvaluatorClient(url: String,
                       connTimeout: Duration = 1.second,
                       readTimeout: Duration = 10.seconds) {
 
-  lazy val api = new EvaluatorAPI(url, authKey, connTimeout, readTimeout)
+  lazy val api: EvaluatorAPI[EvaluatorOp] =
+    new EvaluatorAPI(url, authKey, connTimeout, readTimeout)
 
 }
 

--- a/project/EvaluatorBuild.scala
+++ b/project/EvaluatorBuild.scala
@@ -37,7 +37,7 @@ object EvaluatorBuild extends AutoPlugin {
 
 
   private[this] def baseSettings = Seq(
-    version := "0.0.2-SNAPSHOT",
+    version := "0.0.3-SNAPSHOT",
     organization := "org.scala-exercises",
     scalaVersion := "2.11.8",
     scalafmtConfig in ThisBuild := Some(file(".scalafmt")),


### PR DESCRIPTION
The API helper needs to be parameterized so that the evaluation algebra can be injected into a higher algebra.

The Ops API already supports this, via inject. However, it requires full parameters to each method call-- `url`, `authKey`, etc. The API interface is much more useful as these parameters aren't required.