### PR TITLE
Use ivy to retrieve dependencies before resorting to coursier

### DIFF
--- a/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
@@ -56,9 +56,10 @@ class Evaluator(timeout: FiniteDuration = 20.seconds)(
 
   def resolveArtifacts(remotes: Seq[Remote],
                        dependencies: Seq[Dependency]): Task[Resolution] = {
-    val resolution                    = Resolution(dependencies.map(dependencyToModule).toSet)
-    val repositories: Seq[Repository] = remotes.map(remoteToRepository)
-    val fetch                         = Fetch.from(repositories, Cache.fetch())
+    val resolution = Resolution(dependencies.map(dependencyToModule).toSet)
+    val repositories: Seq[Repository] = Cache.ivy2Local +: remotes.map(
+        remoteToRepository)
+    val fetch = Fetch.from(repositories, Cache.fetch())
     resolution.process.run(fetch)
   }
 

--- a/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
@@ -57,8 +57,7 @@ class Evaluator(timeout: FiniteDuration = 20.seconds)(
   def resolveArtifacts(remotes: Seq[Remote],
                        dependencies: Seq[Dependency]): Task[Resolution] = {
     val resolution = Resolution(dependencies.map(dependencyToModule).toSet)
-    val repositories: Seq[Repository] = Cache.ivy2Local +: remotes.map(
-        remoteToRepository)
+    val repositories: Seq[Repository] = Cache.ivy2Local +: remotes.map(remoteToRepository)
     val fetch = Fetch.from(repositories, Cache.fetch())
     resolution.process.run(fetch)
   }


### PR DESCRIPTION
This PR adds a fix to the evaluator to retrieve dependencies from ivy before trying to get them through coursier, something that will help during local development of libraries. Could you please review, @dialelo @raulraja @juanpedromoreno? Thanks!!