### PR TITLE
Tests ensuring the server integrity when running third-party code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,22 @@ lazy val `evaluator-server` = (project in file("server"))
   .settings(dockerSettings)
   .settings(compilerDependencySettings: _*)
 
+lazy val `smoketests` = (project in file("smoketests"))
+  .dependsOn(`evaluator-server`)
+  .settings(
+    name := "evaluator-server-smoke-tests",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % v('scalaTest) % "test",
+      "org.http4s" %% "http4s-blaze-client" % v('http4s),
+      "org.http4s" %% "http4s-circe" % v('http4s),
+      "io.circe" %% "circe-core" % v('circe),
+      "io.circe" %% "circe-generic" % v('circe),
+      "io.circe" %% "circe-parser" % v('circe),
+      "com.pauldijou" %% "jwt-core" % v('jwtcore)
+    )
+
+  )
+
 onLoad in Global := (Command.process("project evaluator-server", _: State)) compose (onLoad in Global).value
 addCommandAlias("publishSignedAll", ";evaluator-sharedJS/publishSigned;evaluator-sharedJVM/publishSigned;evaluator-clientJS/publishSigned;evaluator-clientJVM/publishSigned")
 
@@ -99,7 +115,7 @@ lazy val dockerSettings = Seq(
       .run("useradd", "-m", "evaluator")
       .user("evaluator")
       .add(artifact, artifactTargetPath)
-      .cmdRaw(s"java -Dhttp.port=$$PORT -jar $artifactTargetPath")
+      .cmdRaw(s"java -Dhttp.port=$$PORT -Deval.auth.secretKey=$$EVAL_SECRET_KEY -jar $artifactTargetPath")
   },
   imageNames in docker := Seq(ImageName(repository = "registry.heroku.com/scala-evaluator-sandbox/web"))
 )

--- a/smoketests/src/test/scala/org/scalaexercises/evaluator/Smoketests.scala
+++ b/smoketests/src/test/scala/org/scalaexercises/evaluator/Smoketests.scala
@@ -1,0 +1,79 @@
+package org.scalaexercises.evaluator
+
+import org.scalatest._
+import org.http4s._
+import org.http4s.client.blaze._
+import org.http4s.circe._
+import io.circe.generic.auto._
+import scalaz.concurrent.Task
+import scala.concurrent.duration._
+
+import pdi.jwt.{Jwt, JwtAlgorithm}
+
+class Smoketests extends FunSpec with Matchers with CirceInstances {
+
+  case class EvaluatorResponse(msg: String,
+                               value: String,
+                               valueType: String,
+                               compilationInfos: Map[String, String])
+
+  implicit val decoder: EntityDecoder[EvaluatorResponse] =
+    jsonOf[EvaluatorResponse]
+
+  val validToken = Jwt.encode(
+    """{"user": "scala-exercises"}""",
+    auth.secretKey,
+    JwtAlgorithm.HS256)
+
+  def makeRequest(code: String)(
+    expectation: EvaluatorResponse => Unit,
+    failExpectation: Throwable => Unit = fail(_)): Unit = {
+
+    val request = new Request(
+      method = Method.POST,
+      uri = Uri.uri("http://scala-evaluator-sandbox.herokuapp.com/eval"),
+      headers = Headers(headers)
+    ).withBody(
+      s"""{"resolvers" : [], "dependencies" : [], "code" : "$code"}""")
+
+    val task = client.expect[EvaluatorResponse](request)
+
+    val response = task.unsafePerformSyncAttemptFor(60.seconds)
+    response.fold(failExpectation, expectation)
+  }
+
+  val headers = List(
+    Header("Content-Type", "application/json").parsed,
+    Header("x-scala-eval-api-token", validToken).parsed
+  )
+
+  val client = PooledHttp1Client()
+
+  describe("Querying the /eval endpoint") {
+    it("should succeed for a simple request") {
+      makeRequest("1 + 1") { evaluatorResponse =>
+        evaluatorResponse.value shouldBe "2"
+      }
+    }
+
+    it("should continue to work after calling System.exit") {
+      makeRequest("System.exit(1)")(
+        expectation = _ => fail("Request should not succeed"),
+        failExpectation = _ => ()
+      )
+
+      makeRequest("1 + 1") { evaluatorResponse =>
+        evaluatorResponse.value shouldBe "2"
+      }
+    }
+
+    it("should not expose sensitive details by calling sys.env") {
+      val keywords = List("password", "key", "api")
+      makeRequest("sys.env") { evaluatorResponse =>
+        keywords.foreach(kw =>
+            evaluatorResponse.value.contains(kw) shouldBe false)
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
A small suite of tests for ensuring that the deployed docker container works, and does not leak any more information that it is needed.

I've included three simple tests:
  1. The endpoint works
  1. The endpoint recovers from someone calling `System.exit`
  1. The endpoint does not expose anything of interest through `sys.env`

If you can think of other tests, please let me know.

I've kept these tests separate from other endpoint tests in the code as this is really to make sure that the _endpoint_ works, rather than the functionality of the endpoint itself.

--

These tests sit in their own SBT package, and are currently not run as part of any automated build.  Due to Docker on Heroku being in beta and still very new, it is not possible to use Heroku's deployment pipelines with Docker yet. I think we have a few options here as to what to do with them.
  1. Run the tests when Travis is triggered to deploy a Docker container, and notify of any issues. Manual intervention to fix/rollback.
  1. Set up our own pipeline, deploying to a different staging URL, running the smoketests there and deploying to the production URL on success. Will have to be hand-rolled, but I don't think this would be much effort.

Once Heroku can deploy pipelines of Docker containers, we should definitely move over to using that.

@raulraja Thoughts? I think setting our own pipeline wouldn't take very long and I'm all for no manual intervention, but as I'd be hand-rolling this, I just wanted to see what you think before I go down this route.