### PR TITLE
Update the deployment and smoketests to point to the production URL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,5 +117,5 @@ lazy val dockerSettings = Seq(
       .add(artifact, artifactTargetPath)
       .cmdRaw(s"java -Dhttp.port=$$PORT -Deval.auth.secretKey=$$EVAL_SECRET_KEY -jar $artifactTargetPath")
   },
-  imageNames in docker := Seq(ImageName(repository = "registry.heroku.com/scala-evaluator-sandbox/web"))
+  imageNames in docker := Seq(ImageName(repository = "registry.heroku.com/scala-evaluator/web"))
 )

--- a/smoketests/src/test/scala/org/scalaexercises/evaluator/Smoketests.scala
+++ b/smoketests/src/test/scala/org/scalaexercises/evaluator/Smoketests.scala
@@ -31,7 +31,7 @@ class Smoketests extends FunSpec with Matchers with CirceInstances {
 
     val request = new Request(
       method = Method.POST,
-      uri = Uri.uri("http://scala-evaluator-sandbox.herokuapp.com/eval"),
+      uri = Uri.uri("http://scala-evaluator.herokuapp.com/eval"),
       headers = Headers(headers)
     ).withBody(
       s"""{"resolvers" : [], "dependencies" : [], "code" : "$code"}""")


### PR DESCRIPTION
We are now deploying changes to the correct Heroku app. This deployment has been tested against Kazari already, with success, and the smoketests pass too.

Following this PR, we will be redeploying sbot and scala-exercises to this URL.

@raulraja It's a small change, can you review please?