### PR TITLE
Fixing macroparadise's inclusion as a compiler plugin

### DIFF
--- a/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
@@ -73,7 +73,7 @@ class Evaluator(timeout: FiniteDuration = 20.seconds)(
           val newJars = jars.mkString(File.pathSeparator)
           classpath.value = newJars + File.pathSeparator + classpath.value
 
-          (jars map (_.toString)).find(_.contains("paradise")) match {
+          (jars map (_.toString)).filter(_.endsWith(".jar")).find(_.contains("paradise")) match {
             case Some(compilerJar) => plugin.appendToValue(compilerJar)
             case None              =>
           }


### PR DESCRIPTION
This PR resolves #55 and fixes the macroparadise's inclusion as a compiler plugin including it only when the `.jar` is present.

@juanpedromoreno could you please review? 

Thanks!