### PR TITLE
Adding unit tests for the evaluator client side

### DIFF
--- a/client/shared/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
+++ b/client/shared/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
@@ -24,7 +24,7 @@ object EvaluatorResponses {
 
   case class EvaluationResult[A](result: A, statusCode: Int, headers: Map[String, String])
 
-  sealed abstract class EvaluationException(msg: String, cause: Option[Throwable] = None)
+  abstract class EvaluationException(msg: String, cause: Option[Throwable] = None)
       extends Throwable(msg) {
     cause foreach initCause
   }

--- a/client/shared/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
+++ b/client/shared/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
@@ -8,16 +8,16 @@ package org.scalaexercises.evaluator.api
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalaexercises.evaluator.EvaluatorResponses.EvaluationResponse
-import org.scalaexercises.evaluator.http.HttpClient
+import org.scalaexercises.evaluator.http.{HttpClient, HttpClientLike}
 import org.scalaexercises.evaluator.{Decoders, Dependency, EvalRequest, EvalResponse}
 
 import scala.concurrent.Future
 
-class Evaluator {
+trait EvaluatorLike {
 
   import Decoders._
 
-  private val httpClient = new HttpClient
+  val httpClient: HttpClientLike[EvalResponse] = new HttpClient
 
   def eval(
       url: String,
@@ -25,9 +25,11 @@ class Evaluator {
       resolvers: List[String] = Nil,
       dependencies: List[Dependency] = Nil,
       code: String): Future[EvaluationResponse[EvalResponse]] =
-    httpClient.post[EvalResponse](
+    httpClient.post(
       url = url,
       secretKey = authKey,
       data = EvalRequest(resolvers, dependencies, code).asJson.noSpaces)
 
 }
+
+class Evaluator extends EvaluatorLike

--- a/client/shared/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
+++ b/client/shared/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
@@ -18,10 +18,10 @@ object HttpClient {
 
 }
 
-class HttpClient {
+trait HttpClientLike[A] {
 
   import HttpClient._
-  def post[A](
+  def post(
       url: String,
       secretKey: String,
       method: String = "post",
@@ -34,3 +34,5 @@ class HttpClient {
         .withBody(data)
         .run)
 }
+
+class HttpClient[A] extends HttpClientLike[A]

--- a/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
+++ b/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
@@ -82,13 +82,7 @@ class EvaluatorClientSpec extends AsyncFunSpec with Matchers {
     }
   }
 
-}
-
-object EvaluatorClientSpec {
-
-  case class TestError(msg: String, cause: Option[Throwable] = None) extends EvaluationException(msg, cause)
-
-  def httpClientWithValidResult[A](result: A, statusCode: Int, isError: Boolean) = new HttpClientLike[A] {
+  private def httpClientWithValidResult[A](result: A, statusCode: Int, isError: Boolean) = new HttpClientLike[A] {
     override def post(url: String, secretKey: String, method: String, headers: Headers, data: String)(implicit D: Decoder[A]): Future[EvaluationResponse[A]] =
       Future {
         if (isError) {
@@ -102,6 +96,12 @@ object EvaluatorClientSpec {
         }
       }
   }
+
+}
+
+object EvaluatorClientSpec {
+  
+  case class TestError(msg: String, cause: Option[Throwable] = None) extends EvaluationException(msg, cause)
 
   val malformedJsonResponse = "error"
   val validJsonResponse =

--- a/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
+++ b/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * scala-exercises - evaluator-client
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package org.scalaexercises.evaluator
+
+import fr.hmil.roshttp.response.SimpleHttpResponse
+import fr.hmil.roshttp.util.HeaderMap
+import io.circe.Decoder
+import org.scalaexercises.evaluator.EvaluatorResponses.{EvaluationException, EvaluationResponse, EvaluationResult, JsonParsingException, UnexpectedException, toEntity}
+import org.scalaexercises.evaluator.api.EvaluatorLike
+import org.scalaexercises.evaluator.http.HttpClient.Headers
+import org.scalaexercises.evaluator.http.HttpClientLike
+import org.scalatest.{AsyncFunSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EvaluatorClientSpec extends AsyncFunSpec with Matchers {
+  import EvaluatorClientSpec._
+
+  describe("evaluator client") {
+    it("return a correct 200 response if the evaluation returns without errors") {
+      val client = httpClientWithValidResult(EvalResponse("ok"), 200, isError = false)
+
+      val evaluator = new EvaluatorLike {
+        override val httpClient: HttpClientLike[EvalResponse] = client
+      }
+
+      val result = evaluator.eval("", "", List(), List(), "")
+
+      result.map { r =>
+        assert(r.isRight)
+        r should matchPattern {
+          case Right(EvaluationResult(EvalResponse("ok", _, _, _, _), 200, _)) ⇒
+        }
+      }
+    }
+
+    it("return an error response if the evaluation returns without errors") {
+      val client = httpClientWithValidResult(EvalResponse("error"), 400, isError = true)
+
+      val evaluator = new EvaluatorLike {
+        override val httpClient: HttpClientLike[EvalResponse] = client
+      }
+
+      val result = evaluator.eval("", "", List(), List(), "")
+
+      result.map { r =>
+        assert(r.isLeft)
+        r should matchPattern {
+          case Left(TestError(_, _)) ⇒
+        }
+      }
+    }
+  }
+
+  describe("evaluator responses") {
+    it("return a correct entity when receiving an valid response") {
+      import org.scalaexercises.evaluator.Decoders._
+
+      toEntity[EvalResponse](Future(new SimpleHttpResponse(200, HeaderMap(), validJsonResponse))).map { r =>
+        r should matchPattern {
+          case Right(EvaluationResult(_, 200, _)) ⇒
+        }
+      }
+    }
+    it("return a JsonParsingException when receiving a malformed response") {
+      toEntity[String](Future(new SimpleHttpResponse(200, HeaderMap(), malformedJsonResponse))).map { r =>
+        r should matchPattern {
+          case Left(JsonParsingException(_, _)) ⇒
+        }
+      }
+    }
+    it("return a UnexpectedException when receiving an error response") {
+      toEntity[String](Future(new SimpleHttpResponse(500, HeaderMap(), malformedJsonResponse))).map { r =>
+        r should matchPattern {
+          case Left(UnexpectedException(_)) ⇒
+        }
+      }
+    }
+  }
+
+}
+
+object EvaluatorClientSpec {
+
+  case class TestError(msg: String, cause: Option[Throwable] = None) extends EvaluationException(msg, cause)
+
+  def httpClientWithValidResult[A](result: A, statusCode: Int, isError: Boolean) = new HttpClientLike[A] {
+    override def post(url: String, secretKey: String, method: String, headers: Headers, data: String)(implicit D: Decoder[A]): Future[EvaluationResponse[A]] =
+      Future {
+        if (isError) {
+          Left {
+            new TestError("Test error")
+          }
+        } else {
+          Right {
+            EvaluationResult(result, statusCode, Map())
+          }
+        }
+      }
+  }
+
+  val malformedJsonResponse = "error"
+  val validJsonResponse =
+    s"""
+       |{
+       |  "msg": "ok",
+       |  "compilationInfos": {}
+       |}
+     """.stripMargin
+
+}

--- a/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
+++ b/client/shared/src/test/scala/org/scalaexercises/evaluator/EvaluatorClientSpec.scala
@@ -13,8 +13,6 @@ import org.scalaexercises.evaluator.api.EvaluatorLike
 import org.scalaexercises.evaluator.http.HttpClient.Headers
 import org.scalaexercises.evaluator.http.HttpClientLike
 import org.scalatest.{AsyncFunSpec, Matchers}
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class EvaluatorClientSpec extends AsyncFunSpec with Matchers {
@@ -100,7 +98,7 @@ class EvaluatorClientSpec extends AsyncFunSpec with Matchers {
 }
 
 object EvaluatorClientSpec {
-  
+
   case class TestError(msg: String, cause: Option[Throwable] = None) extends EvaluationException(msg, cause)
 
   val malformedJsonResponse = "error"


### PR DESCRIPTION
This PR adds a missing test suite to the evaluator client side to verify that responses from the evaluator side are correctly passed through our client code, while also checking the JSON parsing of the available messages.