### PR TITLE
Adds Exclusions to dependency API

### DIFF
--- a/client/src/main/scala/org/scalaexercises/evaluator/Decoders.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/Decoders.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator
@@ -16,5 +18,6 @@ object Decoders {
     Decoder.forProduct2("message", "pos")(CompilationInfo.apply)
 
   implicit val decodeEvalResponse: Decoder[EvalResponse] =
-    Decoder.forProduct5("msg", "value", "valueType", "consoleOutput", "compilationInfos")(EvalResponse.apply)
+    Decoder.forProduct5("msg", "value", "valueType", "consoleOutput", "compilationInfos")(
+      EvalResponse.apply)
 }

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorAPI.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorClient.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/EvaluatorResponses.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/api/Evaluator.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator.api

--- a/client/src/main/scala/org/scalaexercises/evaluator/free/algebra/EvaluatorOps.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/free/algebra/EvaluatorOps.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator.free.algebra

--- a/client/src/main/scala/org/scalaexercises/evaluator/free/interpreters/Interpreter.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/free/interpreters/Interpreter.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator.free.interpreters

--- a/client/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/http/HttpClient.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator.http

--- a/client/src/main/scala/org/scalaexercises/evaluator/http/HttpRequestBuilder.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/http/HttpRequestBuilder.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator.http

--- a/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
+++ b/client/src/main/scala/org/scalaexercises/evaluator/implicits.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-client
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-client
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
@@ -42,11 +42,17 @@ class Evaluator[F[_]: Sync](timeout: FiniteDuration = 20.seconds)(
 
   def remoteToRepository(remote: Remote): Repository = MavenRepository(remote)
 
-  def dependencyToModule(dependency: Dependency): coursier.Dependency =
-    coursier.Dependency.of(
-      Module(Organization(dependency.groupId), ModuleName(dependency.artifactId)),
-      dependency.version
-    )
+  def dependencyToModule(dependency: Dependency): coursier.Dependency = {
+    val exclusions = dependency.exclusions map {
+      case Exclusion(org, mod) => (Organization(org), ModuleName(mod))
+    }
+    coursier.Dependency
+      .of(
+        Module(Organization(dependency.groupId), ModuleName(dependency.artifactId)),
+        dependency.version
+      )
+      .withExclusions(exclusions)
+  }
 
   val cache: FileCache[F] = FileCache[F].noCredentials
 

--- a/server/src/main/scala/org/scalaexercises/evaluator/services.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/services.scala
@@ -28,7 +28,8 @@ object services {
 
   import EvalResponse.messages._
 
-  def evaluatorInstance[F[_]: ConcurrentEffect: ContextShift: Timer: Sync] = new Evaluator[F](20 seconds)
+  def evaluatorInstance[F[_]: ConcurrentEffect: ContextShift: Timer: Sync] =
+    new Evaluator[F](20 seconds)
 
   val corsHeaders = Seq(
     Header("Vary", "Origin,Access-Control-Request-Methods"),

--- a/server/src/test/scala/org/scalaexercises/evaluator/EvalEndpointSpec.scala
+++ b/server/src/test/scala/org/scalaexercises/evaluator/EvalEndpointSpec.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-server
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-server
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/server/src/test/scala/org/scalaexercises/evaluator/EvaluatorSpec.scala
+++ b/server/src/test/scala/org/scalaexercises/evaluator/EvaluatorSpec.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-server
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-server
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/server/src/test/scala/org/scalaexercises/evaluator/helper.scala
+++ b/server/src/test/scala/org/scalaexercises/evaluator/helper.scala
@@ -1,6 +1,8 @@
 /*
- * scala-exercises - evaluator-server
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ *  scala-exercises - evaluator-server
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package org.scalaexercises.evaluator

--- a/shared/src/main/scala/org/scalaexercises/evaluator/types.scala
+++ b/shared/src/main/scala/org/scalaexercises/evaluator/types.scala
@@ -37,7 +37,12 @@ final case class CompilationError[A](compilationInfos: CI) extends EvalResult[A]
 
 final case class GeneralError[A](stack: Throwable) extends EvalResult[A]
 
-final case class Dependency(groupId: String, artifactId: String, version: String)
+final case class Exclusion(organization: String, moduleName: String)
+final case class Dependency(
+    groupId: String,
+    artifactId: String,
+    version: String,
+    exclusions: Set[Exclusion] = Set.empty)
 
 final case class EvalRequest(
     resolvers: List[String] = Nil,


### PR DESCRIPTION
This PR allows to optionally exclude transitive dependencies in code evaluations. For example:

```bash
curl -X "POST" "http://localhost:8080/eval" \
     -H 'Content-Type: application/json' \
     -H 'x-scala-eval-api-token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eW91ciBpZGVudGl0eQ.cfH43Wa7k_w1i0W2pQhV1k21t2JqER9lw5EpJcENRMI' \
     -d $'{
  "code": "{import stdlib._;import stdlib.Asserts._;import org.scalatest._;def a(n: Int) = n*2;a(1) should be(2)}",
  "resolvers": [
    "https://oss.sonatype.org/content/repositories/snapshots",
    "https://oss.sonatype.org/content/repositories/releases"
  ],
  "dependencies": [
    {
      "groupId": "org.scala-exercises",
      "exclusions": [
        {
          "organization": "io.monix",
          "moduleName": "monix_2.11"
        }
      ],
      "artifactId": "exercises-stdlib_2.11",
      "version": "0.5.0-SNAPSHOT"
    }
  ]
}'
```