### PR TITLE
Closing JarFile instances

### DIFF
--- a/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
+++ b/server/src/main/scala/org/scalaexercises/evaluator/evaluation.scala
@@ -471,8 +471,9 @@ class ${className} extends (() => Any) with java.io.Serializable {
         val nestedClassPath: IO[String] =
           jarResource
             .use(jar => IO(jar.getManifest.getMainAttributes.getValue("Class-Path")))
-            .handleError { throwable: Throwable =>
-              throw new CompilerException(List(List(throwable.getMessage)))
+            .handleError {
+              case scala.util.control.NonFatal(e) =>
+                throw new CompilerException(List(List(e.getMessage)))
             }
 
         nestedClassPath.map {


### PR DESCRIPTION
In the Eval class, we are creating instances of `JarFile` which are not garbaged correctly. This only calls close when we obtain the data we want. 