### PR TITLE
Adds scalatestplus-scalacheck dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ ensime.sbt
 
 # OSX
 .DS_Store
+
+.metals/

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,15 +19,16 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     object V {
-      lazy val cats        = "2.1.0"
-      lazy val http4s      = "0.21.0-M6"
-      lazy val circe       = "0.12.3"
-      lazy val log4s       = "1.7.0"
-      lazy val scalatest   = "3.1.0"
-      lazy val slf4jSimple = "1.7.30"
-      lazy val jwtCore     = "4.2.0"
-      lazy val coursier    = "2.0.0-RC5-6"
-      lazy val config      = "1.4.0"
+      lazy val cats                = "2.1.0"
+      lazy val http4s              = "0.21.0-M6"
+      lazy val circe               = "0.12.3"
+      lazy val log4s               = "1.7.0"
+      lazy val scalatest           = "3.1.0"
+      lazy val scalatestplusScheck = "3.1.0.0-RC2"
+      lazy val slf4jSimple         = "1.7.30"
+      lazy val jwtCore             = "4.2.0"
+      lazy val coursier            = "2.0.0-RC5-6"
+      lazy val config              = "1.4.0"
     }
 
     lazy val dockerSettings = Seq(
@@ -50,8 +51,7 @@ object ProjectPlugin extends AutoPlugin {
       },
       imageNames in docker := Seq(
         ImageName(repository =
-          s"registry.heroku.com/${sys.props.getOrElse("evaluator.heroku.name", "scala-evaluator")}/web"
-        )
+          s"registry.heroku.com/${sys.props.getOrElse("evaluator.heroku.name", "scala-evaluator")}/web")
       )
     )
 
@@ -77,7 +77,8 @@ object ProjectPlugin extends AutoPlugin {
         %%("coursier", V.coursier),
         %%("coursier-cache", V.coursier),
         "io.get-coursier" %% "coursier-cats-interop" % V.coursier,
-        %%("scalatest", V.scalatest)
+        %%("scalatest", V.scalatest),
+        "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck
       )
     )
 
@@ -96,7 +97,8 @@ object ProjectPlugin extends AutoPlugin {
         %%("http4s-blaze-client", V.http4s),
         %%("http4s-circe", V.http4s),
         %%("jwt-core", V.jwtCore),
-        %%("scalatest", V.scalatest) % "test"
+        %%("scalatest", V.scalatest) % Test,
+        "org.scalatestplus"          %% "scalatestplus-scalacheck" % V.scalatestplusScheck % Test
       )
     )
 


### PR DESCRIPTION
No real clue about the problem, but this adds explicitly the `scalatestplus-scalacheck` dependency to the evaluator, trying to fix:

```bash
java.lang.NoClassDefFoundError: org/scalatestplus/scalacheck/UnquotedString$
	at org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.$anonfun$check$3(CheckerAsserting.scala:119)
```

when a test fails in the scalacheck library.